### PR TITLE
adding exception to getSeveralTracks

### DIFF
--- a/src/lib/tracks.ts
+++ b/src/lib/tracks.ts
@@ -2,6 +2,11 @@ import { getAxiosSpotifyInstance } from './driver';
 import Track from './models/track/track';
 
 export const getSeveralTracks = async (ids: number[] | string[]) => {
+    if (ids.length > 50) {
+        const exceptionLink =
+            'https://developer.spotify.com/documentation/web-api/reference/tracks/get-several-tracks/';
+        throw `The maximum number of tracks is 50. See ${exceptionLink} for details`;
+    }
     const params = { params: { ids } };
     const response = await getAxiosSpotifyInstance().get('/tracks', params);
     return response.data.tracks.map((trackJson: any) => new Track(trackJson));


### PR DESCRIPTION
Spotify's API suggests that only 50 tracks can be get at once. This PR creates an exception to handle it.