### PR TITLE
Fix circle-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
     build:
         docker:
-            - image: circleci/node:7.10
+            - image: circleci/node:8.9
 
         working_directory: ~/repo
 


### PR DESCRIPTION
There was a problem with the node version on circle:
![image](https://user-images.githubusercontent.com/11728746/47691829-5629df80-dbd2-11e8-82bb-0397e59a52b6.png)
Updated to node 8.9, a LTS version