### PR TITLE
Create function to retrieve detailed data on PlayHistory's model

### DIFF
--- a/src/lib/models/player/play-history.ts
+++ b/src/lib/models/player/play-history.ts
@@ -1,10 +1,11 @@
 import Context from './context';
 import Track from '../track/track';
+import { getAlbum, getArtist, getPlaylist } from '../..';
 
 class PlayHistory {
     track: Track;
 
-    playedAt: string; // Timestamp
+    playedAt: string;
 
     context: Context | null;
 
@@ -12,6 +13,23 @@ class PlayHistory {
         this.track = new Track(json.track);
         this.playedAt = json.played_at;
         this.context = json.context ? new Context(json.context) : null;
+    }
+
+    getContextData(): Promise<any> {
+        if (this.context) {
+            const [, type, id] = this.context.uri.split(':');
+            switch (type) {
+                case 'album':
+                    return getAlbum(id);
+                case 'artist':
+                    return getArtist(id);
+                case 'playlist':
+                    return getPlaylist(id);
+                default:
+                    return getAlbum(this.track.album.id);
+            }
+        }
+        return getAlbum(this.track.album.id);
     }
 }
 


### PR DESCRIPTION
Determines the type of the context (artist, album or playlist) through the context's uri. By default, if the context is found to be null, the album in which the track is placed is returned as its context.