### PR TITLE
Update functions to use optional objects for optional parameters

### DIFF
--- a/src/lib/albums.ts
+++ b/src/lib/albums.ts
@@ -30,14 +30,15 @@ export const getSeveralAlbums = async (
 
 export const getAlbumTracks = async (
     id: string,
-    offset = 0,
-    limit = 20,
-    market?: string
+    params?: {
+        offset?: number;
+        limit?: number;
+        market?: string;
+    }
 ): Promise<Page<TrackSimplified>> => {
-    const params = { params: { offset, limit, market } };
     const response = await getAxiosSpotifyInstance().get(
         `/albums/${id}/tracks`,
-        params
+        { params }
     );
     return new Page<TrackSimplified>(response.data, TrackSimplified);
 };

--- a/src/lib/albums.ts
+++ b/src/lib/albums.ts
@@ -1,19 +1,20 @@
 import { getAxiosSpotifyInstance } from './driver';
 import { Album, TrackSimplified, Page } from './models';
 
-export const getAlbum = async (id: string, market?: string): Promise<Album> => {
-    const params = { params: { market } };
-    const response = await getAxiosSpotifyInstance().get(
-        `/albums/${id}`,
-        params
-    );
+export const getAlbum = async (
+    id: string,
+    params?: { market?: string }
+): Promise<Album> => {
+    const response = await getAxiosSpotifyInstance().get(`/albums/${id}`, {
+        params,
+    });
 
     return new Album(response.data);
 };
 
 export const getSeveralAlbums = async (
     ids: string[],
-    market?: string
+    params?: { market?: string }
 ): Promise<Album[]> => {
     if (ids.length > 20) {
         const exceptionLink =
@@ -22,8 +23,8 @@ export const getSeveralAlbums = async (
             `The maximum number of albums is 20. See ${exceptionLink} for details`
         );
     }
-    const params = { params: { market, ids: ids.join(',') } };
-    const response = await getAxiosSpotifyInstance().get('/albums', params);
+    const config = { params: { ...params, ids: ids.join(',') } };
+    const response = await getAxiosSpotifyInstance().get('/albums', config);
 
     return response.data.albums.map((albumJson: any) => new Album(albumJson));
 };

--- a/src/lib/artists.ts
+++ b/src/lib/artists.ts
@@ -23,16 +23,25 @@ export const getSeveralArtists = async (ids: string[]): Promise<Artist[]> => {
 
 export const getArtistAlbums = async (
     id: string,
-    offset = 0,
-    limit = 20,
-    includeGroups?: string[],
-    market?: string
+    params?: {
+        offset?: number;
+        limit?: number;
+        includeGroups?: string[];
+        market?: string;
+    }
 ): Promise<Page<AlbumSimplified>> => {
-    const params: any = { params: { offset, limit, market } };
-    if (includeGroups) params.params.include_groups = includeGroups.join(',');
+    const config = {
+        params: {
+            ...params,
+            include_groups:
+                params && params.includeGroups
+                    ? params.includeGroups.join(',')
+                    : '',
+        },
+    };
     const response = await getAxiosSpotifyInstance().get(
         `/artists/${id}/albums`,
-        params
+        config
     );
     return new Page<AlbumSimplified>(response.data, AlbumSimplified);
 };

--- a/src/lib/artists.ts
+++ b/src/lib/artists.ts
@@ -14,8 +14,8 @@ export const getSeveralArtists = async (ids: string[]): Promise<Artist[]> => {
             `The maximum number of artists is 50. See ${exceptionLink} for details`
         );
     }
-    const params = { params: { ids } };
-    const response = await getAxiosSpotifyInstance().get('/artists', params);
+    const config = { params: { ids } };
+    const response = await getAxiosSpotifyInstance().get('/artists', config);
     return response.data.artists.map(
         (artistJson: any) => new Artist(artistJson)
     );
@@ -61,10 +61,10 @@ export const getArtistTopTracks = async (
     id: string,
     market: string
 ): Promise<Track[]> => {
-    const params = { params: { market } };
+    const config = { params: { market } };
     const response = await getAxiosSpotifyInstance().get(
         `/artists/${id}/top-tracks`,
-        params
+        config
     );
     return response.data.tracks.map((trackJson: any) => new Track(trackJson));
 };

--- a/src/lib/follow.ts
+++ b/src/lib/follow.ts
@@ -1,11 +1,11 @@
 import { getAxiosSpotifyInstance } from './driver';
 import { Artist } from './models';
 
-export const getFollowedArtists = async (
-    limit: number = 20,
-    after?: string
-): Promise<Artist[]> => {
-    if (limit < 1 || limit > 50) {
+export const getFollowedArtists = async (params?: {
+    limit?: number;
+    after?: string;
+}): Promise<Artist[]> => {
+    if (params && params.limit && (params.limit < 1 || params.limit > 50)) {
         const exceptionLink =
             'https://developer.spotify.com/documentation/web-api/reference/follow/get-followed/';
         throw new Error(
@@ -13,11 +13,10 @@ export const getFollowedArtists = async (
         );
     }
 
-    const afterQuery = after ? after : null;
-    const params = { params: { limit, type: 'artist', after: afterQuery } };
+    const config = { params: { ...params, type: 'artist' } };
     const response = await getAxiosSpotifyInstance().get(
         '/me/following',
-        params
+        config
     );
 
     return response.data.artists.items.map(
@@ -41,10 +40,10 @@ export const isFollowing = async (
         );
     }
 
-    const params = { params: { type, ids: ids.join() } };
+    const config = { params: { type, ids: ids.join() } };
     const response = await getAxiosSpotifyInstance().get(
         '/me/following/contains',
-        params
+        config
     );
 
     return response.data;
@@ -62,10 +61,10 @@ export const checkUsersFollowingPlaylist = async (
         );
     }
 
-    const params = { params: { ids: ids.join() } };
+    const config = { params: { ids: ids.join() } };
     const response = await getAxiosSpotifyInstance().get(
         `/playlists/${playlistId}/followers/contains`,
-        params
+        config
     );
 
     return response.data;

--- a/src/lib/playlists.ts
+++ b/src/lib/playlists.ts
@@ -6,20 +6,32 @@ export const getPlaylist = async (id: string) => {
     return new Playlist(response.data);
 };
 
-export const getPlaylistTracks = async (id: string, offset = 0, limit = 20) => {
-    const params = { params: { offset, limit } };
+export const getPlaylistTracks = async (
+    id: string,
+    params?: {
+        fields?: string;
+        limit?: number;
+        offset?: number;
+        market?: string;
+    }
+) => {
     const response = await getAxiosSpotifyInstance().get(
         `/playlists/${id}/tracks`,
-        params
+        { params }
     );
     return new Page<PlaylistTrack>(response.data, PlaylistTrack);
 };
 
-export const getUserPlaylists = async (id: string, offset = 0, limit = 20) => {
-    const params = { params: { offset, limit } };
+export const getUserPlaylists = async (
+    id: string,
+    params?: {
+        limit?: number;
+        offset?: number;
+    }
+) => {
     const response = await getAxiosSpotifyInstance().get(
         `/users/${id}/playlists`,
-        params
+        { params }
     );
     return new Page<PlaylistSimplified>(response.data, PlaylistSimplified);
 };

--- a/src/lib/tracks.ts
+++ b/src/lib/tracks.ts
@@ -40,10 +40,11 @@ export const getAudioFeaturesForTrack = async (id: string) => {
 };
 
 export const getAudioFeaturesForSeveralTracks = async (ids: string[]) => {
-    const params = { ids: ids.join(',') };
-    const response = await getAxiosSpotifyInstance().get(`/audio-features`, {
-        params,
-    });
+    const config = { params: { ids: ids.join(',') } };
+    const response = await getAxiosSpotifyInstance().get(
+        `/audio-features`,
+        config
+    );
     return response.data.audio_features.map(
         (audioFeaturesJson: any) => new AudioFeatures(audioFeaturesJson)
     );

--- a/test/albums.test.ts
+++ b/test/albums.test.ts
@@ -72,8 +72,7 @@ describe('Album requests', () => {
         it('response should match all paging object attributes', async () => {
             const albumTracksResponse = await getAlbumTracks(
                 '3yGwYUrWqe6PHf0IcUdkbZ',
-                0,
-                2
+                { offset: 0, limit: 2 }
             );
             checkMatchingPagingObjectAttributes(
                 albumTracksResponse,
@@ -84,8 +83,7 @@ describe('Album requests', () => {
         it('response should match all custom paging object attributes', async () => {
             const albumTracksResponse = await getAlbumTracks(
                 '3yGwYUrWqe6PHf0IcUdkbZ',
-                0,
-                2
+                { offset: 0, limit: 2 }
             );
             expect(albumTracksResponse.hasNext()).to.be.true;
             expect(albumTracksResponse.hasPrevious()).to.be.false;

--- a/test/artists.test.ts
+++ b/test/artists.test.ts
@@ -71,15 +71,14 @@ describe('Artist requests', () => {
         beforeEach(() => {
             nock('https://api.spotify.com/v1')
                 .get('/artists/1WgXqy2Dd70QQOU7Ay074N/albums')
-                .query({ offset: 0, limit: 5 })
+                .query({ offset: 0, limit: 5, include_groups: '' })
                 .reply(200, artistAlbumsMock);
         });
 
         it('response should match all albums attributes', async () => {
             const artistAlbumsResponse = await getArtistAlbums(
                 '1WgXqy2Dd70QQOU7Ay074N',
-                0,
-                5
+                { offset: 0, limit: 5 }
             );
             checkMatchingPagingObjectAttributes(
                 artistAlbumsResponse,


### PR DESCRIPTION
Current use of optional parameters in certain functions was confusing and problematic when dealing with more than one per time. This issue was solved by implementing _params_ objects in every function that provides the use of optional parameters.

Minor edits include changing some objects' names from _params_ to _config_ in order to avoid confusion.