### PR TITLE
Improve checking tests readability

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "scripts": {
         "start": "ts-node src/start.ts",
         "build": "rimraf build && tsc && webpack",
-        "lint": "tslint -c tslint.json 'src/**/*.ts'",
+        "lint": "tslint -c tslint.json 'src/**/*.ts' 'test/**/*.ts'",
         "test": "mocha -r ts-node/register test/*.test.ts"
     },
     "husky": {

--- a/test/albums.test.ts
+++ b/test/albums.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import nock from 'nock';
 
-import { albumMock, AlbumMock } from './mocks/albums/album.mock';
+import { albumMock } from './mocks/albums/album.mock';
 import { severalAlbumsMock } from './mocks/albums/several-albums.mock';
 import { albumTracksMock } from './mocks/albums/album-tracks.mock';
 import {
@@ -53,9 +53,9 @@ describe('Album requests', () => {
                 '3dB0bCgmpEgCSr3aU1bOtv',
             ]);
 
-            for (let i = 0; i < severalAlbumsResponse.length; i++) {
+            for (let i = 0; i < severalAlbumsResponse.length; i += 1) {
                 const albumResponse: Album = severalAlbumsResponse[i];
-                const albumMock: AlbumMock = severalAlbumsMock.albums[i];
+                const albumMock: any = severalAlbumsMock.albums[i];
                 checkMatchingAlbumAttributes(albumResponse, albumMock);
             }
         });

--- a/test/artists.test.ts
+++ b/test/artists.test.ts
@@ -1,13 +1,10 @@
 import nock from 'nock';
 
-import { artistMock, ArtistMock } from './mocks/artists/artist.mock';
+import { artistMock } from './mocks/artists/artist.mock';
 import { severalArtistsMock } from './mocks/artists/several-artists.mock';
 import { artistAlbumsMock } from './mocks/artists/artist-albums.mock';
 import { artistRelatedArtistsMock } from './mocks/artists/artist-related-artists.mock';
-import {
-    artistTopTracksMock,
-    TrackMock,
-} from './mocks/artists/artist-top-tracks.mock';
+import { artistTopTracksMock } from './mocks/artists/artist-top-tracks.mock';
 import {
     checkMatchingArtistAttributes,
     checkMatchingPagingObjectAttributes,
@@ -59,7 +56,7 @@ describe('Artist requests', () => {
                 '1WgXqy2Dd70QQOU7Ay074N',
             ]);
 
-            for (let i = 0; i < severalArtistsResponse.length; i++) {
+            for (let i = 0; i < severalArtistsResponse.length; i += 1) {
                 const artistResponse = severalArtistsResponse[i];
                 const artistMock = severalArtistsMock.artists[i];
                 checkMatchingArtistAttributes(artistResponse, artistMock);
@@ -99,10 +96,9 @@ describe('Artist requests', () => {
                 '1WgXqy2Dd70QQOU7Ay074N'
             );
 
-            for (let i = 0; i < artistRelatedArtistsResponse.length; i++) {
+            for (let i = 0; i < artistRelatedArtistsResponse.length; i += 1) {
                 const artistResponse: Artist = artistRelatedArtistsResponse[i];
-                const artistMock: ArtistMock =
-                    artistRelatedArtistsMock.artists[i];
+                const artistMock: any = artistRelatedArtistsMock.artists[i];
                 checkMatchingArtistAttributes(artistResponse, artistMock);
             }
         });
@@ -122,9 +118,9 @@ describe('Artist requests', () => {
                 'BR'
             );
 
-            for (let i = 0; i < artistTopTracksResponse.length; i++) {
+            for (let i = 0; i < artistTopTracksResponse.length; i += 1) {
                 const topTrackResponse: Track = artistTopTracksResponse[i];
-                const topTrackMock: TrackMock = artistTopTracksMock.tracks[i];
+                const topTrackMock = artistTopTracksMock.tracks[i];
                 checkMatchingTrackAttributes(topTrackResponse, topTrackMock);
             }
         });

--- a/test/common/matching-attributes.test.ts
+++ b/test/common/matching-attributes.test.ts
@@ -11,106 +11,106 @@ import {
     CursorBasedPage,
     PrivateUser,
     PublicUser,
+    ArtistSimplified,
 } from '../../src/lib/models';
+
+import _ from 'lodash';
 
 import { AlbumMock } from '../mocks/albums/album.mock';
 import { ArtistMock } from '../mocks/artists/artist.mock';
 import { TrackMock } from '../mocks/artists/artist-top-tracks.mock';
 
-export const checkMatchingAlbumAttributes = (
-    response: Album,
-    mock: AlbumMock
+export const checkMatchingArtistSimplifiedAttributes = (
+    response: ArtistSimplified,
+    mock: any
 ) => {
-    expect(response.albumType).to.be.equal(mock.album_type);
-    expect(response.artists).to.have.lengthOf(mock.artists.length);
-    expect(response.availableMarkets).to.be.eql(mock.available_markets);
-    expect(response.copyrights).to.be.eql(mock.copyrights);
-    expect(response.externalIds).to.be.eql(mock.external_ids);
-    expect(response.externalUrls).to.be.eql(mock.external_urls);
-    expect(response.genres).to.be.eql(mock.genres);
-    expect(response.href).to.be.equal(mock.href);
-    expect(response.id).to.be.equal(mock.id);
-    expect(response.images).to.be.eql(mock.images);
-    expect(response.label).to.be.equal(mock.label);
-    expect(response.name).to.be.equal(mock.name);
-    expect(response.popularity).to.be.equal(mock.popularity);
-    expect(response.releaseDate).to.be.equal(mock.release_date);
-    expect(response.releaseDatePrecision).to.be.equal(
-        mock.release_date_precision
-    );
-    expect(response.totalTracks).to.be.equal(mock.total_tracks);
-    expect(response.tracks.total).to.be.equal(mock.tracks.total);
-    expect(response.type).to.be.equal(mock.type);
-    expect(response.uri).to.be.equal(mock.uri);
+    const attributes = ['externalUrls', 'href', 'id', 'name', 'type', 'uri'];
+    checkMatchingObjectAttributes(response, mock, attributes);
+};
+
+export const checkMatchingAlbumAttributes = (response: Album, mock: any) => {
+    const attributes = [
+        'copyrights',
+        'externalIds',
+        'genres',
+        'label',
+        'popularity',
+        'totalTracks',
+    ];
+    checkMatchingObjectAttributes(response, mock, attributes);
+    checkMatchingAlbumSimplifiedAttributes(response, mock);
 };
 
 export const checkMatchingAlbumSimplifiedAttributes = (
     response: AlbumSimplified,
     mock: any
 ) => {
-    expect(response.albumType).to.be.equal(mock.album_type);
-    expect(response.artists).to.have.lengthOf(mock.artists.length);
-    expect(response.externalUrls).to.be.eql(mock.external_urls);
-    expect(response.href).to.be.equal(mock.href);
-    expect(response.id).to.be.equal(mock.id);
-    expect(response.images).to.be.eql(mock.images);
-    expect(response.name).to.be.equal(mock.name);
-    expect(response.releaseDate).to.be.equal(mock.release_date);
-    expect(response.releaseDatePrecision).to.be.equal(
-        mock.release_date_precision
-    );
-    expect(response.type).to.be.equal(mock.type);
-    expect(response.uri).to.be.equal(mock.uri);
+    const attributes = [
+        'albumType',
+        'availableMarkets',
+        'externalUrls',
+        'href',
+        'id',
+        'images',
+        'name',
+        'releaseDate',
+        'releaseDatePrecision',
+        'type',
+        'uri',
+    ];
+    checkMatchingObjectAttributes(response, mock, attributes);
+    checkMatchingArtistArrays(response.artists, mock.artists);
 };
 
-export const checkMatchingArtistAttributes = (
-    response: Artist,
-    mock: ArtistMock
-) => {
-    expect(response.externalUrls).to.be.eql(mock.external_urls);
-    expect(response.followers).to.be.eql(mock.followers);
-    expect(response.genres).to.be.eql(mock.genres);
-    expect(response.href).to.be.equal(mock.href);
-    expect(response.id).to.be.equal(mock.id);
-    expect(response.images).to.be.eql(mock.images);
-    expect(response.name).to.be.equal(mock.name);
-    expect(response.popularity).to.be.equal(mock.popularity);
-    expect(response.type).to.be.equal(mock.type);
-    expect(response.uri).to.be.equal(mock.uri);
+export const checkMatchingArtistAttributes = (response: Artist, mock: any) => {
+    const attributes = [
+        'externalUrls',
+        'followers',
+        'genres',
+        'href',
+        'id',
+        'images',
+        'name',
+        'popularity',
+        'type',
+        'uri',
+    ];
+    checkMatchingObjectAttributes(response, mock, attributes);
 };
 
-export const checkMatchingTrackAttributes = (
-    response: Track,
-    mock: TrackMock
-) => {
+export const checkMatchingTrackAttributes = (response: Track, mock: any) => {
+    const attributes = [
+        'availableMarkets',
+        'discNumber',
+        'durationMs',
+        'explicit',
+        'externalIds',
+        'externalUrls',
+        'href',
+        'id',
+        'isPlayable',
+        'linkedFrom',
+        'restrictions',
+        'name',
+        'popularity',
+        'previewUrl',
+        'trackNumber',
+        'type',
+        'uri',
+        'isLocal',
+    ];
+    checkMatchingObjectAttributes(response, mock, attributes);
     checkMatchingAlbumSimplifiedAttributes(response.album, mock.album);
-    expect(response.artists).to.have.lengthOf(mock.artists.length);
-    expect(response.discNumber).to.be.equal(mock.disc_number);
-    expect(response.durationMs).to.be.equal(mock.duration_ms);
-    expect(response.explicit).to.be.equal(mock.explicit);
-    expect(response.externalIds).to.be.eql(mock.external_ids);
-    expect(response.externalUrls).to.be.eql(mock.external_urls);
-    expect(response.href).to.be.equal(mock.href);
-    expect(response.id).to.be.equal(mock.id);
-    expect(response.isLocal).to.be.equal(mock.is_local);
-    expect(response.isPlayable).to.be.equal(mock.is_playable);
-    expect(response.name).to.be.equal(mock.name);
-    expect(response.popularity).to.be.equal(mock.popularity);
-    expect(response.previewUrl).to.be.equal(mock.preview_url);
-    expect(response.trackNumber).to.be.equal(mock.track_number);
-    expect(response.type).to.be.equal(mock.type);
-    expect(response.uri).to.be.equal(mock.uri);
+    checkMatchingArtistArrays(response.artists, mock.artists);
 };
 
 export const checkMatchingPagingObjectAttributes = (
     response: Page<any>,
     mock: any
 ) => {
-    expect(response.href).to.be.equal(mock.href);
+    const attributes = ['href', 'limit', 'offset', 'total'];
+    checkMatchingObjectAttributes(response, mock, attributes);
     expect(response.items).to.have.lengthOf(mock.items.length);
-    expect(response.limit).to.be.equal(mock.limit);
-    expect(response.offset).to.be.equal(mock.offset);
-    expect(response.total).to.be.equal(mock.total);
 };
 
 export const checkMatchingCurrentlyPlayingAttributes = (
@@ -119,65 +119,81 @@ export const checkMatchingCurrentlyPlayingAttributes = (
 ) => {
     if (response.context)
         checkMatchingContextAttributes(response.context, mock.context);
-    expect(response.currentlyPlayingType).to.be.equal(
-        mock.currently_playing_type
-    );
-    expect(response.isPlaying).to.be.equal(mock.is_playing);
     if (response.item) checkMatchingTrackAttributes(response.item, mock.item);
-    expect(response.progressMs).to.be.equal(mock.progress_ms);
-    expect(response.timestamp).to.be.equal(mock.timestamp);
+    const attributes = [
+        'currentlyPlayingType',
+        'isPlaying',
+        'progressMs',
+        'timestamp',
+    ];
+    checkMatchingObjectAttributes(response, mock, attributes);
 };
 
 export const checkMatchingContextAttributes = (
     response: Context,
     mock: any
 ) => {
-    expect(response.externalUrls).to.be.eql(mock.external_urls);
-    expect(response.href).to.be.equal(mock.href);
-    expect(response.type).to.be.equal(mock.type);
-    expect(response.uri).to.be.equal(mock.uri);
+    const attributes = ['externalUrls', 'href', 'type', 'uri'];
+    checkMatchingObjectAttributes(response, mock, attributes);
 };
 
 export const checkMatchingCursorBasedPageAttributes = (
     response: CursorBasedPage<any>,
     mock: any
 ) => {
-    expect(response.cursors).to.be.eql(mock.cursors);
-    expect(response.href).to.be.equal(mock.href);
+    const attributes = ['cursors', 'href', 'limit', 'total'];
+    checkMatchingObjectAttributes(response, mock, attributes);
     expect(response.items).to.have.lengthOf(mock.items.length);
-    expect(response.limit).to.be.equal(mock.limit);
     expect(response.next).to.be.equal(mock.next.split('?')[1]);
-    expect(response.total).to.be.equal(mock.total);
 };
 
 export const checkMatchingPrivateUserAttributes = (
     response: PrivateUser,
     mock: any
 ) => {
-    expect(response.birthdate).to.be.equal(mock.birthdate);
-    expect(response.country).to.be.equal(mock.country);
-    expect(response.displayName).to.be.equal(mock.display_name);
-    expect(response.email).to.be.equal(mock.email);
-    expect(response.externalUrls).to.be.eql(mock.external_urls);
-    expect(response.followers).to.be.eql(mock.followers);
-    expect(response.href).to.be.equal(mock.href);
-    expect(response.id).to.be.equal(mock.id);
-    expect(response.images).to.be.eql(mock.images);
-    expect(response.product).to.be.equal(mock.product);
-    expect(response.type).to.be.equal(mock.type);
-    expect(response.uri).to.be.equal(mock.uri);
+    const attributes = ['birthdate', 'country', 'email', 'product'];
+    checkMatchingPublicUserAttributes(response, mock);
+    checkMatchingObjectAttributes(response, mock, attributes);
 };
 
 export const checkMatchingPublicUserAttributes = (
     response: PublicUser,
     mock: any
 ) => {
-    expect(response.displayName).to.be.equal(mock.display_name);
-    expect(response.externalUrls).to.be.eql(mock.external_urls);
-    expect(response.followers).to.be.eql(mock.followers);
-    expect(response.href).to.be.equal(mock.href);
-    expect(response.id).to.be.equal(mock.id);
-    expect(response.images).to.be.eql(mock.images);
-    expect(response.type).to.be.equal(mock.type);
-    expect(response.uri).to.be.equal(mock.uri);
+    const attributes = [
+        'displayName',
+        'externalUrls',
+        'followers',
+        'href',
+        'id',
+        'images',
+        'type',
+        'uri',
+    ];
+    checkMatchingObjectAttributes(response, mock, attributes);
+};
+
+const checkMatchingObjectAttributes = (
+    response: any,
+    mock: any,
+    attributes: string[]
+) => {
+    for (const responseKey of attributes) {
+        const mockKey = _.snakeCase(responseKey);
+        expect(response)
+            .to.have.property(responseKey)
+            .that.is.eql(mock[mockKey]);
+    }
+};
+
+const checkMatchingArtistArrays = (
+    responseArtists: ArtistSimplified[],
+    mockArtists: any[]
+) => {
+    responseArtists.forEach((responseArtist, index) =>
+        checkMatchingArtistSimplifiedAttributes(
+            responseArtist,
+            mockArtists[index]
+        )
+    );
 };

--- a/test/common/matching-attributes.test.ts
+++ b/test/common/matching-attributes.test.ts
@@ -16,10 +16,6 @@ import {
 
 import _ from 'lodash';
 
-import { AlbumMock } from '../mocks/albums/album.mock';
-import { ArtistMock } from '../mocks/artists/artist.mock';
-import { TrackMock } from '../mocks/artists/artist-top-tracks.mock';
-
 export const checkMatchingArtistSimplifiedAttributes = (
     response: ArtistSimplified,
     mock: any

--- a/test/common/matching-attributes.test.ts
+++ b/test/common/matching-attributes.test.ts
@@ -113,9 +113,12 @@ export const checkMatchingCurrentlyPlayingAttributes = (
     response: CurrentlyPlaying,
     mock: any
 ) => {
-    if (response.context)
+    if (response.context) {
         checkMatchingContextAttributes(response.context, mock.context);
-    if (response.item) checkMatchingTrackAttributes(response.item, mock.item);
+    }
+    if (response.item) {
+        checkMatchingTrackAttributes(response.item, mock.item);
+    }
     const attributes = [
         'currentlyPlayingType',
         'isPlaying',

--- a/test/mocks/albums/album.mock.ts
+++ b/test/mocks/albums/album.mock.ts
@@ -939,5 +939,3 @@ export const albumMock = {
     type: 'album',
     uri: 'spotify:album:2iv4eCuGKJYsso1mDR48dt',
 };
-
-export type AlbumMock = typeof albumMock;

--- a/test/mocks/artists/artist-top-tracks.mock.ts
+++ b/test/mocks/artists/artist-top-tracks.mock.ts
@@ -884,5 +884,3 @@ export const artistTopTracksMock = {
         },
     ],
 };
-
-export type TrackMock = typeof artistTopTracksMock.tracks[0];

--- a/test/mocks/artists/artist.mock.ts
+++ b/test/mocks/artists/artist.mock.ts
@@ -34,5 +34,3 @@ export const artistMock = {
     type: 'artist',
     uri: 'spotify:artist:1WgXqy2Dd70QQOU7Ay074N',
 };
-
-export type ArtistMock = typeof artistMock;

--- a/test/tracks.test.ts
+++ b/test/tracks.test.ts
@@ -41,7 +41,7 @@ describe('Track requests', () => {
 
         it('response should match all tracks attributes', async () => {
             const tracksResponse = await getSeveralTracks(tracks, params);
-            for (let i = 0; i < tracksResponse.length; i++) {
+            for (let i = 0; i < tracksResponse.length; i += 1) {
                 const trackResponse = tracksResponse[i];
                 const trackMock = severalTracksMock.tracks[i];
                 checkMatchingTrackAttributes(trackResponse, trackMock);


### PR DESCRIPTION
This pull request simplifies the current implementation of attribute checking tests. Instead of making many manual checks, a list of attributes can be written for an assertion to be run for each one. It also updates tests to fail when objects don't have the tested properties.