### PR TITLE
Add follow tests

### DIFF
--- a/test/follow.test.ts
+++ b/test/follow.test.ts
@@ -1,0 +1,142 @@
+import { expect } from 'chai';
+import nock from 'nock';
+
+import { followedArtistsMock } from './mocks/follow/followed-artists.mock';
+import { checkMatchingArtistAttributes } from './common/matching-attributes.test';
+
+import {
+    init,
+    isFollowing,
+    checkUsersFollowingPlaylist,
+    getFollowedArtists,
+    followArtistsOrUsers,
+    followPlaylist,
+    unfollowArtistsOrUsers,
+    unfollowPlaylist,
+} from '../src/lib';
+
+describe('Follow requests', () => {
+    beforeEach(() => {
+        init({ token: 'SomeToken' });
+    });
+
+    describe('#isFollowing()', () => {
+        beforeEach(() => {
+            nock('https://api.spotify.com/v1')
+                .get('/me/following/contains')
+                .query({ type: 'user', ids: '12180557353' })
+                .reply(200, [true]);
+        });
+
+        it('response should be true if user is followed', async () => {
+            const followingResponse = await isFollowing('user', [
+                '12180557353',
+            ]);
+            expect(followingResponse).to.be.eql([true]);
+        });
+    });
+
+    describe('#checkUsersFollowingPlaylist()', () => {
+        beforeEach(() => {
+            nock('https://api.spotify.com/v1')
+                .get('/playlists/5D0F6KQtqd5HuAVX2sOouy/followers/contains')
+                .query({ ids: '12180557353' })
+                .reply(200, [true]);
+        });
+
+        it('response should be true if playlist is followed', async () => {
+            const followingPlaylistResponse = await checkUsersFollowingPlaylist(
+                '5D0F6KQtqd5HuAVX2sOouy',
+                ['12180557353']
+            );
+            expect(followingPlaylistResponse).to.be.eql([true]);
+        });
+    });
+
+    describe('#getFollowedArtists()', () => {
+        beforeEach(() => {
+            nock('https://api.spotify.com/v1')
+                .get('/me/following')
+                .query({ type: 'artist', limit: 20 })
+                .reply(200, followedArtistsMock);
+        });
+
+        it('response should match all followed artists attributes', async () => {
+            const followedArtistsResponse = await getFollowedArtists({
+                limit: 20,
+            });
+            for (let i = 0; i < followedArtistsResponse.length; i++) {
+                const artistResponse = followedArtistsResponse[i];
+                const artistMock = followedArtistsMock.artists.items[i];
+                checkMatchingArtistAttributes(artistResponse, artistMock);
+            }
+        });
+    });
+
+    describe('#followArtistsOrUsers()', () => {
+        beforeEach(() => {
+            nock('https://api.spotify.com/v1')
+                .put('/me/following', { ids: ['12180557353'] })
+                .query({ type: 'user' })
+                .reply(204);
+        });
+
+        it('response should be empty', async () => {
+            const followArtistOrUsersResponse = await followArtistsOrUsers(
+                ['12180557353'],
+                'user'
+            );
+            expect(followArtistOrUsersResponse).to.be.empty;
+        });
+    });
+
+    describe('#followPlaylist()', () => {
+        beforeEach(() => {
+            nock('https://api.spotify.com/v1')
+                .put('/playlists/5D0F6KQtqd5HuAVX2sOouy/followers', {
+                    public: true,
+                })
+                .reply(200);
+        });
+
+        it('response should be empty', async () => {
+            const followPlaylistResponse = await followPlaylist(
+                '5D0F6KQtqd5HuAVX2sOouy',
+                true
+            );
+            expect(followPlaylistResponse).to.be.empty;
+        });
+    });
+
+    describe('#unfollowArtistsOrUsers()', () => {
+        beforeEach(() => {
+            nock('https://api.spotify.com/v1')
+                .delete('/me/following', { ids: ['12180557353'] })
+                .query({ type: 'user' })
+                .reply(204);
+        });
+
+        it('response should be empty', async () => {
+            const unfollowArtistOrUsersResponse = await unfollowArtistsOrUsers(
+                ['12180557353'],
+                'user'
+            );
+            expect(unfollowArtistOrUsersResponse).to.be.empty;
+        });
+    });
+
+    describe('#unfollowPlaylist()', () => {
+        beforeEach(() => {
+            nock('https://api.spotify.com/v1')
+                .delete('/playlists/5D0F6KQtqd5HuAVX2sOouy/followers')
+                .reply(200);
+        });
+
+        it('response should be empty', async () => {
+            const unfollowPlaylistResponse = await unfollowPlaylist(
+                '5D0F6KQtqd5HuAVX2sOouy'
+            );
+            expect(unfollowPlaylistResponse).to.be.empty;
+        });
+    });
+});

--- a/test/mocks/follow/followed-artists.mock.ts
+++ b/test/mocks/follow/followed-artists.mock.ts
@@ -1,0 +1,53 @@
+export const followedArtistsMock = {
+    artists: {
+        items: [
+            {
+                external_urls: {
+                    spotify:
+                        'https://open.spotify.com/artist/1WgXqy2Dd70QQOU7Ay074N',
+                },
+                followers: {
+                    href: null,
+                    total: 546647,
+                },
+                genres: ['norwegian pop', 'pop'],
+                href:
+                    'https://api.spotify.com/v1/artists/1WgXqy2Dd70QQOU7Ay074N',
+                id: '1WgXqy2Dd70QQOU7Ay074N',
+                images: [
+                    {
+                        height: 640,
+                        url:
+                            'https://i.scdn.co/image/f9f57b4d695b28329f953ece8fbc7fa34dfac344',
+                        width: 640,
+                    },
+                    {
+                        height: 320,
+                        url:
+                            'https://i.scdn.co/image/117b00c6648ddf9ad47eb725df89b717295018d2',
+                        width: 320,
+                    },
+                    {
+                        height: 160,
+                        url:
+                            'https://i.scdn.co/image/7a8e60f50717664f33e8649127c4574b8fc0b293',
+                        width: 160,
+                    },
+                ],
+                name: 'AURORA',
+                popularity: 68,
+                type: 'artist',
+                uri: 'spotify:artist:1WgXqy2Dd70QQOU7Ay074N',
+            },
+        ],
+        next:
+            'https://api.spotify.com/v1/users/jrobsonjr/following?type=artist&after=0aV6DOiouImYTqrR5YlIqx&limit=20',
+        total: 183,
+        cursors: {
+            after: '0aV6DOiouImYTqrR5YlIqx',
+        },
+        limit: 20,
+        href:
+            'https://api.spotify.com/v1/users/jrobsonjr/following?type=artist&limit=20',
+    },
+};


### PR DESCRIPTION
I added all the tests for the `follow` API endpoint. Tests, where several users/artists are specified should probably be added at some point.

Resolves #68