### PR TITLE
Use specific lodash modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,13 @@
     "license": "MIT",
     "version": "0.6.0",
     "dependencies": {
-        "@types/lodash": "^4.14.121",
         "axios": "^0.18.1",
-        "lodash": "^4.17.13"
+        "lodash.differenceby": "^4.8.0",
+        "lodash.intersectionby": "^4.7.0",
+        "lodash.keys": "^4.2.0",
+        "lodash.omit": "^4.5.0",
+        "lodash.pick": "^4.4.0",
+        "lodash.snakecase": "^4.1.1"
     },
     "scripts": {
         "start": "ts-node src/start.ts",
@@ -48,6 +52,12 @@
     "main": "build/index.js",
     "devDependencies": {
         "@types/chai": "^4.1.7",
+        "@types/lodash.differenceby": "^4.8.6",
+        "@types/lodash.intersectionby": "^4.7.6",
+        "@types/lodash.keys": "^4.2.6",
+        "@types/lodash.omit": "^4.5.6",
+        "@types/lodash.pick": "^4.4.6",
+        "@types/lodash.snakecase": "^4.1.6",
         "@types/mocha": "^5.2.5",
         "@types/nock": "^9.3.0",
         "chai": "^4.2.0",

--- a/src/lib/browse.ts
+++ b/src/lib/browse.ts
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { getAxiosSpotifyInstance } from './driver';
 import {
     Category,

--- a/src/lib/models/album/album.ts
+++ b/src/lib/models/album/album.ts
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import AlbumSimplified from './album-simplified';
 import Page from '../paging/page';
 import TrackSimplified from '../track/track-simplified';
@@ -51,7 +49,9 @@ class Album extends AlbumSimplified {
 
     async getDurationMs(): Promise<number> {
         const tracks = await this.getAllTracks();
-        return _.sum(tracks.map(track => track.durationMs));
+        return tracks
+            .map(track => track.durationMs)
+            .reduce((duration1, duration2) => duration1 + duration2, 0);
     }
 }
 

--- a/src/lib/models/track/track.ts
+++ b/src/lib/models/track/track.ts
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import differenceBy from 'lodash.differenceby';
+import intersectionBy from 'lodash.intersectionby';
 
 import AlbumSimplified from '../album/album-simplified';
 import ArtistSimplified from '../artist/artist-simplified';
@@ -23,11 +24,11 @@ class Track extends TrackSimplified {
     }
 
     get mainArtists(): ArtistSimplified[] {
-        return _.intersectionBy(this.artists, this.album.artists, 'id');
+        return intersectionBy(this.artists, this.album.artists, 'id');
     }
 
     get featuredArtists(): ArtistSimplified[] {
-        return _.differenceBy(this.artists, this.album.artists, 'id');
+        return differenceBy(this.artists, this.album.artists, 'id');
     }
 
     get releaseYear() {

--- a/src/lib/player.ts
+++ b/src/lib/player.ts
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import omit from 'lodash.omit';
+import pick from 'lodash.pick';
 
 import { propertiesToSnakeCase } from './util';
 import { getAxiosSpotifyInstance } from './driver';
@@ -113,8 +114,8 @@ export const startUserPlayback = async (params?: {
     offset?: Offset;
     positionMs?: number;
 }) => {
-    const queryParams = propertiesToSnakeCase(_.pick(params, 'deviceId'));
-    const bodyParams = propertiesToSnakeCase(_.omit(params, 'deviceId'), true);
+    const queryParams = propertiesToSnakeCase(pick(params, 'deviceId'));
+    const bodyParams = propertiesToSnakeCase(omit(params, 'deviceId'), true);
     const response = await getAxiosSpotifyInstance().put(
         '/me/player/play',
         bodyParams,

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,13 +1,14 @@
-import _ from 'lodash';
+import keys from 'lodash.keys';
+import snakeCase from 'lodash.snakecase';
 
 export const propertiesToSnakeCase = (object: any, bodyParams?: boolean) => {
     const updatedObject: any = {};
-    const keys = _.keys(object);
-    keys.forEach((key: any) => {
+    const objectKeys = keys(object);
+    objectKeys.forEach((key: any) => {
         const value = object[key];
-        if (_.isArray(value) && !bodyParams) {
-            updatedObject[_.snakeCase(key)] = value.join();
-        } else updatedObject[_.snakeCase(key)] = value;
+        if (Array.isArray(value) && !bodyParams) {
+            updatedObject[snakeCase(key)] = value.join();
+        } else updatedObject[snakeCase(key)] = value;
     });
     return updatedObject;
 };

--- a/test/common/matching-attributes.test.ts
+++ b/test/common/matching-attributes.test.ts
@@ -1,3 +1,4 @@
+import snakeCase from 'lodash.snakecase';
 import { expect } from 'chai';
 
 import {
@@ -17,8 +18,6 @@ import {
     Category,
     RecommendationSeed,
 } from '../../src/lib/models';
-
-import _ from 'lodash';
 
 export const checkMatchingArtistSimplifiedAttributes = (
     response: ArtistSimplified,
@@ -208,7 +207,7 @@ const checkMatchingObjectAttributes = (
     attributes: string[]
 ) => {
     for (const responseKey of attributes) {
-        const mockKey = _.snakeCase(responseKey);
+        const mockKey = snakeCase(responseKey);
         expect(response)
             .to.have.property(responseKey)
             .that.is.eql(mock[mockKey]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,10 +113,52 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.7.tgz#1b8e33b61a8c09cbe1f85133071baa0dbf9fa71a"
   integrity sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==
 
-"@types/lodash@^4.14.121":
-  version "4.14.121"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.121.tgz#9327e20d49b95fc2bf983fc2f045b2c6effc80b9"
-  integrity sha512-ORj7IBWj13iYufXt/VXrCNMbUuCTJfhzme5kx9U/UtcIPdJYuvPDUAlHlbNhz/8lKCLy9XGIZnGrqXOtQbPGoQ==
+"@types/lodash.differenceby@^4.8.6":
+  version "4.8.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.differenceby/-/lodash.differenceby-4.8.6.tgz#35b21bd934f3fb22ea1b5c6cbfbc3a7ab3843c75"
+  integrity sha512-+WrSxp6e4SIIRktC73egYY3ZVF4HpchxftqdfFcPeZTmuQwuIF1uflHVrTBLLgysLemRSrW3iv6o48QIerS4/Q==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash.intersectionby@^4.7.6":
+  version "4.7.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.intersectionby/-/lodash.intersectionby-4.7.6.tgz#2eef2e1c90e9d12474350d7185012508c6aa7321"
+  integrity sha512-8/SPmDqdwB2eo5KX6NnKk8rPMbMy9MHHTGRXBHL5YOGQbwYrZzoswI02jQqZqG2i0cq0SXJt78YBwBDcjmZsew==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash.keys@^4.2.6":
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.keys/-/lodash.keys-4.2.6.tgz#9fb27c91b9d13c523e1d83dc7e20e48f0ce6c087"
+  integrity sha512-FCtZsHapyH/Xu0New7jTLiNwbDfirIgpmii+vndMxM9Guz+kU+uYgKvSaVN4H+CReT6Ht+sfZTrquq0hnSjgxg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash.omit@^4.5.6":
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.omit/-/lodash.omit-4.5.6.tgz#f2a9518259e481a48ff7ec423420fa8fd58933e2"
+  integrity sha512-KXPpOSNX2h0DAG2w7ajpk7TXvWF28ZHs5nJhOJyP0BQHkehgr948RVsToItMme6oi0XJkp19CbuNXkIX8FiBlQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash.pick@^4.4.6":
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.pick/-/lodash.pick-4.4.6.tgz#ae4e8f109e982786313bb6aac4b1a73aefa6e9be"
+  integrity sha512-u8bzA16qQ+8dY280z3aK7PoWb3fzX5ATJ0rJB6F+uqchOX2VYF02Aqa+8aYiHiHgPzQiITqCgeimlyKFy4OA6g==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash.snakecase@^4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.snakecase/-/lodash.snakecase-4.1.6.tgz#85f2b68f67b36c39875f26484b3a78b158ebf060"
+  integrity sha512-qGTf27ncTRUhSwvxD0hzYFmelmTrzEBGvBigrLyx6PRN1rKuy0ZEK+A3X3QnW7k+CwEjIJeAM6XBN4Ay6F03IQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.159"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.159.tgz#61089719dc6fdd9c5cb46efc827f2571d1517065"
+  integrity sha512-gF7A72f7WQN33DpqOWw9geApQPh4M3PxluMtaHxWHXEGSN12/WbcEk/eNSqWNQcQhF66VSZ06vCF94CrHwXJDg==
 
 "@types/mocha@^5.2.5":
   version "5.2.5"
@@ -2160,10 +2202,40 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.differenceby@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/lodash.differenceby/-/lodash.differenceby-4.8.0.tgz#cfd59e94353af5de51da5d302ca4ebff33faac57"
+  integrity sha1-z9WelDU69d5R2l0wLKTr/zP6rFc=
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
+
+lodash.intersectionby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.intersectionby/-/lodash.intersectionby-4.7.0.tgz#12f125e4da00b22290febda1b6c1b68bb9255125"
+  integrity sha1-EvEl5NoAsiKQ/r2htsG2i7klUSU=
+
+lodash.keys@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
+  integrity sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=
+
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+  integrity sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
+
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+  integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
+
+lodash.snakecase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
+  integrity sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=
 
 lodash@^4.17.13, lodash@^4.17.5:
   version "4.17.13"


### PR DESCRIPTION
# Description

As we're trying to reduce the bundle size, this PR removes `lodash` from our dependencies to use specific `lodash` methods. :sparkles: 

## Type of change

Please, add an X to each checkbox that applies to the changes made in this PR.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
